### PR TITLE
Prefer matching the longer delimiter in case they share prefixes

### DIFF
--- a/lib/Hash/Fold.pm
+++ b/lib/Hash/Fold.pm
@@ -189,7 +189,10 @@ sub _split {
     my $hash_delimiter_pattern = quotemeta($hash_delimiter);
     my $array_delimiter_pattern = quotemeta($array_delimiter);
     my $same_delimiter = $array_delimiter eq $hash_delimiter;
-    my @split = split qr{((?:$hash_delimiter_pattern)|(?:$array_delimiter_pattern))}, $path;
+    my $split_pattern = length($hash_delimiter) >= length($array_delimiter)
+        ? qr{((?:$hash_delimiter_pattern)|(?:$array_delimiter_pattern))}
+        : qr{((?:$array_delimiter_pattern)|(?:$hash_delimiter_pattern))};
+    my @split = split $split_pattern, $path;
     my @steps;
 
     # since we require the argument to fold (and unfold) to be a hashref,

--- a/t/delim.t
+++ b/t/delim.t
@@ -1,0 +1,60 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+use Hash::Fold qw(flatten unflatten fold unfold);
+use Test::More;
+
+# Different hash and array delimiters
+{
+    my $nested = {
+        baz => {
+            a => 'b',
+            c => [ 'd', { e => 'f' }, 42 ],
+        },
+    };
+
+    my $delim = {
+        hash_delimiter  => '/',
+        array_delimiter => '#',
+    };
+
+    my $flattened = flatten($nested, $delim);
+    is_deeply $flattened, {
+        'baz/a'     => 'b',
+        'baz/c#0'   => 'd',
+        'baz/c#1/e' => 'f',
+        'baz/c#2'   => 42,
+    };
+
+    my $roundtrip = unflatten($flattened, $delim);
+    is_deeply $roundtrip, $nested;
+}
+
+# Different hash and array delimiter, but shared prefix
+{
+    my $nested = {
+        baz => {
+            a => 'b',
+            c => [ 'd', { e => 'f' }, 42 ],
+        },
+    };
+
+    my $delim = {
+        hash_delimiter  => '/',
+        array_delimiter => '/#',
+    };
+
+    my $flattened = flatten($nested, $delim);
+    is_deeply $flattened, {
+        'baz/a'      => 'b',
+        'baz/c/#0'   => 'd',
+        'baz/c/#1/e' => 'f',
+        'baz/c/#2'   => 42,
+    };
+
+    my $roundtrip = unflatten($flattened, $delim);
+    is_deeply $roundtrip, $nested;
+}
+
+done_testing;

--- a/t/fold.t
+++ b/t/fold.t
@@ -18,15 +18,22 @@ sub folds_ok {
     # report errors with the caller's line number
     local $Test::Builder::Level = $Test::Builder::Level + 1;
 
-    my $got = fold($hash, $options);
+    my $got;
+    eval {
+        $got = fold($hash, $options);
 
-    unless (is_deeply($got, $want)) {
-        warn 'got: ', Dumper($got), $/;
-        warn 'want: ', Dumper($got), $/;
-    }
+        unless (is_deeply($got, $want)) {
+            warn 'got: ', Dumper($got), $/;
+            warn 'want: ', Dumper($got), $/;
+        }
 
-    isnt $got, $want, 'different refs';
-    is_deeply unfold($got, $options), $hash, 'roundtrip: unfold(fold(hash)) == hash';
+        isnt $got, $want, 'different refs';
+        is_deeply unfold($got, $options), $hash, 'roundtrip: unfold(fold(hash)) == hash';
+    };
+
+    ok !$@, 'no exception raised'
+        or diag "Exception: $@";
+
     return $got;
 }
 

--- a/t/fold.t
+++ b/t/fold.t
@@ -275,4 +275,41 @@ sub folds_ok {
     folds_ok $hash => $want;
 }
 
+# Noted potential failure in code
+{
+    my $hash = {
+        foo => 'bar',
+        1   => 'aaagh!',
+        baz => 'quux',
+    };
+
+    my $want = {
+        'foo'    => 'bar',
+        '1'      => 'aaagh!',
+        'baz'    => 'quux',
+    };
+
+    folds_ok $hash => $want;
+}
+
+# Failing extension of noted potential failure in code
+TODO: {
+    my $hash = {
+        bar => {
+            foo => 'bar',
+            1   => 'aaagh!',
+            baz => 'quux',
+        }
+    };
+
+    my $want = {
+        'bar.foo'    => 'bar',
+        'bar.1'      => 'aaagh!',
+        'bar.baz'    => 'quux',
+    };
+
+    local $TODO = "Array/hash ambiguity not resolved correctly at the moment";
+    folds_ok $hash => $want;
+}
+
 done_testing;


### PR DESCRIPTION
I added a failing test with an array delimiter of `/#` and a hash delimiter of `/`, and then fixed it.

While I was at it, I also added some tests (including one TODO) for an ambiguous delimiter case.