### PR TITLE
Switch from Moose to Moo

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for Hash-Fold
 
+0.1.3    
+
+    - Switch from Moose to Moo
+  
 0.1.2 Fri 4 Dec 04:47:18 2015
     - when deserializing, prefer the longest delimiter in the
       case where the array and hash delimiters share a common

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -26,6 +26,7 @@ WriteMakefile(
     PREREQ_PM => {
         'Moo'         => 0,
         'Sub::Exporter' => 0,
+        'Types::Standard' => 0,
     },
     eumm_ge(6.48, { MIN_PERL_VERSION => '5.6.0' }),
     eumm_ge(6.31, { LICENSE => 'artistic_2' }),

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,4 +1,4 @@
-use 5.008003; # perl >= 5.8.3 is required by Moose
+use 5.006000;
 use strict;
 use warnings;
 
@@ -24,10 +24,10 @@ WriteMakefile(
         'Test::More'    => 0,
     },
     PREREQ_PM => {
-        'Moose'         => 0,
+        'Moo'         => 0,
         'Sub::Exporter' => 0,
     },
-    eumm_ge(6.48, { MIN_PERL_VERSION => '5.8.3' }),
+    eumm_ge(6.48, { MIN_PERL_VERSION => '5.6.0' }),
     eumm_ge(6.31, { LICENSE => 'artistic_2' }),
     eumm_ge(6.46, {
         META_MERGE => {

--- a/README
+++ b/README
@@ -16,7 +16,7 @@ DEPENDENCIES
 
 This module requires these other modules and libraries:
 
-    Moose
+    Moo
     Sub::Exporter
 
 COPYRIGHT AND LICENCE

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ my $folded = fold($hash);
 # OPTIONS
 
 As described above, the following options can be supplied as constructor args,
-import args, or per-function overrides. Under the hood, they are ([Moose](https://metacpan.org/pod/Moose))
+import args, or per-function overrides. Under the hood, they are ([Moo](https://metacpan.org/pod/Moo))
 attributes which can be wrapped and overridden like any other attributes.
 
 ## array_delimiter

--- a/lib/Hash/Fold.pm
+++ b/lib/Hash/Fold.pm
@@ -3,6 +3,7 @@ package Hash::Fold;
 use Carp qw(confess);
 use Moo;
 use Scalar::Util qw(refaddr);
+use Types::Standard qw(Str CodeRef);
 
 use Sub::Exporter -setup => {
     exports => [
@@ -20,39 +21,26 @@ use constant {
 
 our $VERSION = '0.1.2';
 
-my $CodeRef = sub {
-    my $attr = shift;
-    sub { die ("expected a 'CodeRef'." )
-	    unless 'CODE' eq ref $_[0]
-	}
- };
-
-my $Str = sub {
-    my $attr = shift;
-    sub { die ("expected a 'Str'" )
-	    unless ref(\$_[0]) eq 'SCALAR' || ref(\(my $val = $_[0])) eq 'SCALAR' };
-};
-
 has on_object => (
-    isa      => $CodeRef->('on_object'),
+    isa      => CodeRef,
     is       => 'ro',
     default  => sub { sub { $_[1] } }, # return the value unchanged
 );
 
 has on_cycle => (
-    isa      => $CodeRef->('on_cycle'),
+    isa      => CodeRef,
     is       => 'ro',
     default  => sub { sub { } }, # do nothing
 );
 
 has hash_delimiter => (
-    isa      => $Str->('hash_delimiter'),
+    isa      => Str,
     is       => 'ro',
     default  => '.',
 );
 
 has array_delimiter => (
-    isa      => $Str->('array_delimiter'),
+    isa      => Str,
     is       => 'ro',
     default  => '.',
 );

--- a/lib/Hash/Fold.pm
+++ b/lib/Hash/Fold.pm
@@ -1,7 +1,7 @@
 package Hash::Fold;
 
 use Carp qw(confess);
-use Moose;
+use Moo;
 use Scalar::Util qw(refaddr);
 
 use Sub::Exporter -setup => {
@@ -20,26 +20,39 @@ use constant {
 
 our $VERSION = '0.1.2';
 
+my $CodeRef = sub {
+    my $attr = shift;
+    sub { die ("expected a 'CodeRef'." )
+	    unless 'CODE' eq ref $_[0]
+	}
+ };
+
+my $Str = sub {
+    my $attr = shift;
+    sub { die ("expected a 'Str'" )
+	    unless ref(\$_[0]) eq 'SCALAR' || ref(\(my $val = $_[0])) eq 'SCALAR' };
+};
+
 has on_object => (
-    isa      => 'CodeRef',
+    isa      => $CodeRef->('on_object'),
     is       => 'ro',
     default  => sub { sub { $_[1] } }, # return the value unchanged
 );
 
 has on_cycle => (
-    isa      => 'CodeRef',
+    isa      => $CodeRef->('on_cycle'),
     is       => 'ro',
     default  => sub { sub { } }, # do nothing
 );
 
 has hash_delimiter => (
-    isa      => 'Str',
+    isa      => $Str->('hash_delimiter'),
     is       => 'ro',
     default  => '.',
 );
 
 has array_delimiter => (
-    isa      => 'Str',
+    isa      => $Str->('array_delimiter'),
     is       => 'ro',
     default  => '.',
 );
@@ -419,7 +432,7 @@ imported with options baked in e.g.:
 =head1 OPTIONS
 
 As described above, the following options can be supplied as constructor args,
-import args, or per-function overrides. Under the hood, they are (L<Moose>)
+import args, or per-function overrides. Under the hood, they are (L<Moo>)
 attributes which can be wrapped and overridden like any other attributes.
 
 =head2 array_delimiter


### PR DESCRIPTION
Why move from Moose to Moo?

1.  Hash::Fold doesn't use the MOP in Moose, so it can easily be converted to Moo.
2.  If it's in Moo, existing Moo code won't need to drag in Moose to use it.
3.  Existing Moose code won't be affected, as Moo will inflate to Moose if used from Moose.
4.  Moo doesn't need XS code to run, so can be fatpacked, while Moo and Mouse can't
5.  I don't think Mouse plays well with Moose or Moo, but I could be mistaken.