### PR TITLE
produce better errors for incompatible paths

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -23,11 +23,13 @@ WriteMakefile(
     },
     BUILD_REQUIRES => {
         'Test::More' => 0,
+        'Test::Fatal' => 0,
     },
     PREREQ_PM             => {
         'Moo'             => 0,
         'Sub::Exporter'   => 0,
         'Types::Standard' => 0,
+        'Throwable::Error' => 0,
     },
     eumm_ge(6.48, { MIN_PERL_VERSION => '5.8.0' }),
     eumm_ge(6.31, { LICENSE => 'artistic_2' }),

--- a/lib/Hash/Fold.pm
+++ b/lib/Hash/Fold.pm
@@ -74,15 +74,13 @@ sub fold {
 }
 
 sub _build_path {
-    my ( $self, $steps ) = @_;
+    my ($self, $steps) = @_;
 
     my @path = map {
         $_->[VALUE],
-          (
-              $_->[TYPE] == ARRAY ? $self->array_delimiter
-            : $_->[TYPE] == HASH  ? $self->hash_delimiter
-            :                       ''
-          )
+        $_->[TYPE] == ARRAY ? $self->array_delimiter
+        : $_->[TYPE] == HASH  ? $self->hash_delimiter
+        :                       ''
     } @$steps;
     # last element is a delimiter; don't need that
     pop @path;
@@ -102,18 +100,18 @@ sub unfold {
         my $value = $hash->{$key};
         my $steps = $self->_split($key);
 
-        eval { $self->_set($target, $steps, $value) };
-        if ( $@ ) {
-            my $error   = $@;
+        eval {$self->_set($target, $steps, $value)};
+        if ($@) {
+            my $error = $@;
             my $o_steps = $self->_split($key);
             # want everything that was removed from $steps
-            splice( @$o_steps, -1, @$steps + 1 );
+            splice(@$o_steps, -1, @$steps + 1);
             my $context = $self->_build_path($o_steps);
 
-            my ( $article, $type )
+            my ($article, $type)
               = $error =~ /ARRAY/ ? qw[ an array ]
               : $error =~ /HASH/  ? qw[ a hash ]
-              :                     ( undef, undef );
+              :                     (undef, undef);
 
             my $message
               = defined $type
@@ -121,11 +119,11 @@ sub unfold {
               : "unanticipated error: $error";
 
             require Hash::Fold::Error;
-            Hash::Fold::Error->throw( {
-                message   => $message,
-                path      => $context,
+            Hash::Fold::Error->throw({
+                message => $message,
+                path => $context,
                 type => $type
-            } );
+            });
         }
     }
 

--- a/lib/Hash/Fold.pm
+++ b/lib/Hash/Fold.pm
@@ -103,25 +103,28 @@ sub unfold {
         eval {$self->_set($target, $steps, $value)};
         if ($@) {
             my $error = $@;
+
             my $o_steps = $self->_split($key);
-            # want everything that was removed from $steps
-            splice(@$o_steps, -1, @$steps + 1);
-            my $context = $self->_build_path($o_steps);
+            my $context_type = $o_steps->[@$o_steps - @$steps - 1][TYPE];
 
             my ($article, $type)
-              = $error =~ /ARRAY/ ? qw[ an array ]
-              : $error =~ /HASH/  ? qw[ a hash ]
-              :                     (undef, undef);
+              = $context_type == ARRAY ? qw[ an array ]
+              : $context_type == HASH  ? qw[ a hash ]
+              :                             (undef, undef);
+
+            # want everything that was removed from $steps
+            splice(@$o_steps, -1, @$steps + 1);
+            my $path = $self->_build_path($o_steps);
 
             my $message
               = defined $type
-              ? "Attempt to use non-${type} ($context) as ${article} ${type}"
+              ? "Attempt to use non-${type} ($path) as ${article} ${type}"
               : "unanticipated error: $error";
 
             require Hash::Fold::Error;
             Hash::Fold::Error->throw({
                 message => $message,
-                path => $context,
+                path => $path,
                 type => $type
             });
         }

--- a/lib/Hash/Fold/Error.pm
+++ b/lib/Hash/Fold/Error.pm
@@ -3,8 +3,13 @@ package Hash::Fold::Error;
 use Moo;
 extends 'Throwable::Error';
 
-has path => ( is => 'ro' );
-has type => ( is => 'ro' );
+has path => (
+    is => 'ro',
+);
+
+has type => (
+    is => 'ro',
+);
 
 1;
 

--- a/lib/Hash/Fold/Error.pm
+++ b/lib/Hash/Fold/Error.pm
@@ -1,0 +1,59 @@
+package Hash::Fold::Error;
+
+use Moo;
+extends 'Throwable::Error';
+
+has path => ( is => 'ro' );
+has type => ( is => 'ro' );
+
+1;
+
+__END__
+
+=head1 NAME
+
+ Hash::Fold::Error
+
+=head1 SYNOPSIS
+
+  use Hash::Fold::Error;
+
+  Hash::Fold::Error->throw($message);
+  Hash::Fold::Error->throw({
+                    message => $message,
+                    path => $path,
+                    type => $type,
+  });
+
+=head1 DESCRIPTION
+
+L<Hash::Fold> will throw on object instantiated from this class on error.
+
+=head1 ATTRIBUTES
+
+=head3 path
+
+If the C<path> attribute is defined, the error was thrown during
+merging or unfolding, and indicates the location in the structure
+which was inappropriately used as an array or a hash.
+
+L</type> is set to either C<array> or C<hash>.
+
+=head3 type
+
+When defined, C<type> indicates the type of the structure
+that caused the error.
+
+=head1 AUTHOR
+
+chocolateboy <chocolate@cpan.org>
+
+=head1 COPYRIGHT
+
+Copyright (c) 2018 by chocolateboy.
+
+This is free software; you can redistribute it and/or modify it under the
+terms of the Artistic License 2.0.
+
+=cut
+

--- a/t/merge.t
+++ b/t/merge.t
@@ -98,34 +98,34 @@ subtest 'incompatible structures' => sub {
     # to make sure there's no off-by-one error.
 
     my $test = sub {
-        my ( $component, $hash1, $hash2, $hash3 ) = @_;
+        my ($component, $hash1, $hash2, $hash3) = @_;
         like(
-            exception { merge( $hash1, $hash2 ) },
+            exception { merge($hash1, $hash2) },
                   qr/attempt to use non-array \($component\) as an array/i, "array on scalar"
         );
 
         like(
-            exception { merge( $hash2, $hash1 ) },
+            exception { merge($hash2, $hash1) },
                   qr/attempt to use non-array \($component\) as an array/i, "scalar on array"
         );
 
         like(
-            exception { merge( $hash2, $hash3 ) },
+            exception { merge($hash2, $hash3) },
                   qr/attempt to use non-hash \($component\) as a hash/i, "hash on scalar"
         );
 
         like(
-            exception { merge( $hash3, $hash2 ) },
+            exception { merge($hash3, $hash2) },
                   qr/attempt to use non-hash \($component\) as a hash/i, "scalar on hash"
         );
 
         like(
-            exception { merge( $hash3, $hash1 ) },
+            exception { merge($hash3, $hash1) },
                   qr/attempt to use non-hash \($component\) as a hash/i, "hash on array"
         );
 
         like(
-            exception { merge( $hash1, $hash3 ) },
+            exception { merge($hash1, $hash3) },
                   qr/attempt to use non-hash \($component\) as a hash/i, "array on hash"
         );
     };


### PR DESCRIPTION
- errors are now thrown as Hash::Fold::Error objects so more
  information can be returned

- attempts to use a path component incompatibly (e.g. as a hash or
  array reference when its not) result in an error object with
  additional information so upstream code can handle the error
  appropriately.