### PR TITLE
empty hashrefs should be ignored

### DIFF
--- a/t/merge.t
+++ b/t/merge.t
@@ -69,7 +69,7 @@ sub merge_ok {
     merge_ok [ $hash1, $hash2, $hash3 ], {
         foo  => 1,
         bar  => 3,
-        baz  => 5,
+        baz  => 4,
     };
 }
 

--- a/t/merge.t
+++ b/t/merge.t
@@ -51,6 +51,28 @@ sub merge_ok {
     };
 }
 
+# empty hashes should be ignored
+{
+    my $hash1 = {
+        foo => 1,
+        bar => 2,
+    };
+
+    my $hash2 = {
+        bar  => 3,
+        baz  => 4,
+    };
+
+    my $hash3 = {
+    };
+
+    merge_ok [ $hash1, $hash2, $hash3 ], {
+        foo  => 1,
+        bar  => 3,
+        baz  => 5,
+    };
+}
+
 # where there are conflicts, confirm the rightmost array takes precedence
 # (also confirms more than 2 hashes can be merged)
 {


### PR DESCRIPTION
Hello,

when an empty hashref is in a merge, the result is broken (also there are some warnings on stderr).

I am not sure if this is desired and how to fix it.

```
$ prove -l t/merge.t
t/merge.t .. 1/10 Use of uninitialized value $target_key in hash element at /path/to/Hash-Fold/lib/Hash/Fold.pm li
ne 329.
Use of uninitialized value in hash element at /path/to/Hash-Fold/lib/Hash/Fold.pm line 392.
Use of uninitialized value $target_key in hash element at /path/to/Hash-Fold/lib/Hash/Fold.pm line 329.
Use of uninitialized value in hash element at /path/to/Hash-Fold/lib/Hash/Fold.pm line 392.

#   Failed test at t/merge.t line 69.
#     Structures begin differing at:
#          $got->{} = HASH(0x3389828)
#     $expected->{} = Does not exist
got (sub): {
  '' => {},
  'bar' => 3,
  'baz' => 4,
  'foo' => 1
}

want: {
  'bar' => 3,
  'baz' => 4,
  'foo' => 1
}


#   Failed test at t/merge.t line 69.
#     Structures begin differing at:
#          $got->{} = HASH(0x33a6490)
#     $expected->{} = Does not exist
got (method): {
  '' => {},
  'bar' => 3,
  'baz' => 4,
  'foo' => 1
}

want: {
  'bar' => 3,
  'baz' => 4,
  'foo' => 1
}

# Looks like you planned 10 tests but ran 12.
# Looks like you failed 2 tests of 12 run.
t/merge.t .. Dubious, test returned 2 (wstat 512, 0x200)
Failed 2/10 subtests 

Test Summary Report
-------------------
t/merge.t (Wstat: 512 Tests: 12 Failed: 4)
  Failed tests:  3-4, 11-12
  Non-zero exit status: 2
  Parse errors: Bad plan.  You planned 10 tests but ran 12.
Files=1, Tests=12,  0 wallclock secs ( 0.02 usr  0.00 sys +  0.15 cusr  0.00 csys =  0.17 CPU)
Result: FAIL
```